### PR TITLE
fix(docs): fixed incorrect name of method in README.md & typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Klonen Sie dieses Repository direkt in Eclipse und importieren Sie das Projekt. 
 
 ## Aufgabe 1
 
-Im Projekt finden Sie eine Klasse `Document`, die eine Textdatei einlesen kann, und zwar über die (statische) Methods `Document.loadFromFile()`. Sie finden außerdem eine Datei `data/dracula.txt`, wobei es sich um den Text von Bram Stokers' *Dracula* handelt.
+Im Projekt finden Sie eine Klasse `Document`, die eine Textdatei einlesen kann, und zwar über die (statische) Methode `Document.readFromFile()`. Sie finden außerdem eine Datei `data/dracula.txt`, wobei es sich um den Text von Bram Stokers' *Dracula* handelt.
 
 Machen Sie zunächstmal die Klasse `Document` iterierbar, so dass sie über die Tokens im Dokument iteriert, die jeweils als Strings repräsentiert werden (d.h. die Klasse `Document` sollte das Interface `Iterable<String>` implementieren). Zur Erkennung einzelner Tokens können Sie auf die Klasse `StringTokenizer` zurückgreifen, die ebenfalls zum  `java.util` package gehört ([javadoc](https://docs.oracle.com/javase/8/docs/api/java/util/StringTokenizer.html)). 
 

--- a/src/idh/java/MyLinkedList.java
+++ b/src/idh/java/MyLinkedList.java
@@ -20,7 +20,7 @@ public class MyLinkedList<T> implements List<T> {
     }
 
     /**
-     * We only need to store the very first element of our list, because it will now
+     * We only need to store the very first element of our list, because it will know
      * whether there is a next element.
      */
     ListElement first;


### PR DESCRIPTION
Mir ist im `README.md` ein kleiner Fehler aufgefallen. Die Methode in der `Document` Klasse hat einen leicht anderen Namen (`readFromFile` anstatt `loadFromFile`).
